### PR TITLE
fix: resolve github action failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: "cd integration && bazel build //..."
+        # This is a test.
+        run: "cd integration && bazel build //... && cat bazel-bin/fusesoc.txt"
 

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ bazel run //third_party/fusesoc:requirements.update
 ### Example use in a repository
 
 ```
-cd integration && bazel build //...
+cd integration && bazel build //... && cat bazel-bin/fusesoc.txt
 ```

--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -9,8 +9,8 @@ genrule(
     srcs = [ ],
     outs = [ "fusesoc.txt" ],
     tools = [
-        "@rules_fusesoc//third_party/fusesoc:fusesoc",
+        "@rules_fusesoc//third_party/fusesoc:run_fusesoc",
         requirement("fusesoc"),
     ],
-    cmd = "$(location @rules_fusesoc//third_party/fusesoc:fusesoc) --help > $@",
+    cmd = "$(location @rules_fusesoc//third_party/fusesoc:run_fusesoc) --help > $@",
 )

--- a/third_party/fusesoc/BUILD.bazel
+++ b/third_party/fusesoc/BUILD.bazel
@@ -16,8 +16,11 @@ compile_pip_requirements(
 )
 
 py_binary(
-    name = "fusesoc",
-    srcs = [ "fusesoc.py" ],
+    # This target may not be named `fusesoc` since it will conflict with the
+    # `fusesoc` library in `deps`. This works locally for some reason, but
+    # fails in github actions.
+    name = "run_fusesoc",
+    srcs = [ "run_fusesoc.py" ],
     deps = [
         requirement("fusesoc"),
     ],

--- a/third_party/fusesoc/run_fusesoc.py
+++ b/third_party/fusesoc/run_fusesoc.py
@@ -1,6 +1,3 @@
-import os
-print(os.environ["PYTHONPATH"])
-
 import sys
 from fusesoc.main import main
 if __name__ == '__main__':


### PR DESCRIPTION
Renamed the `fusesoc` script to `run_fusesoc`.

The name of the fusesoc script `fusesoc` conflicted with the
actual fusesoc library package. This caused the build to fail
on Github Actions.  Renaming the script fixed the issue.

Surprisingly, things worked just fine locally.