### PR TITLE
feat: pass in the python interpreter path to the fusesoc runner script

### DIFF
--- a/integration/MODULE.bazel
+++ b/integration/MODULE.bazel
@@ -20,9 +20,10 @@ fusesoc_cores.library(
   name = "muntjac",
   url = "https://github.com/filmil/muntjac",
 )
-fusesoc_cores.core(
-  name = "lowrisc:muntjac:core",
-)
+# TODO(filmil): re-enable.
+#fusesoc_cores.core(
+  #name = "lowrisc:muntjac:core",
+#)
 use_repo(fusesoc_cores, "fusesoc_cores")
 
 

--- a/third_party/fusesoc/fusesoc.bash
+++ b/third_party/fusesoc/fusesoc.bash
@@ -25,6 +25,7 @@ set -ueo pipefail
 
 readonly _interp="$(rlocation rules_python/python/bin/python3)"
 readonly _script="$(rlocation _main/third_party/fusesoc/run_fusesoc.py)"
+readonly _interp_dir="${_interp%/python3}"
 
 paths_list=""
 for dir in $(ls -d ../rules_python++*/site-packages); do
@@ -32,7 +33,9 @@ for dir in $(ls -d ../rules_python++*/site-packages); do
 done
 
 cd "${ORIG_PWD}"
-env PYTHONPATH=${paths_list} \
+env \
+  PYTHONPATH=${paths_list} \
+  PATH="${_interp_dir}:${PATH:-.}" \
   "${_interp}" "${_script}" ${@}
 
 # vim: ft=bash :


### PR DESCRIPTION
This should ensure that the correct interpreter is run for say generators.