### PR TITLE
chore: migrate to rules_bid 2.2.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ bazel_dep(name = "rules_python", version = "1.6.3")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_shar", version = "0.5.0")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
-bazel_dep(name = "bazel_rules_bid", version = "1.2.2")
+bazel_dep(name = "rules_bid", version = "2.2.2")
 bazel_dep(name = "gazelle", version = "0.47.0")
 bazel_dep(name = "rules_go", version = "0.59.0")
 

--- a/build/fusesoc_run.bzl
+++ b/build/fusesoc_run.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_rules_bid//build:rules.bzl", "run_docker_cmd")
+load("@rules_bid//build:rules.bzl", "run_docker_cmd")
 
 
 CONTAINER = "filipfilmar/eda_tools:0.0"
@@ -156,7 +156,7 @@ fusesoc_run = rule(
             doc = "A dictionary of mounts to define for the run."
         ),
         "_script": attr.label(
-            default = Label("@bazel_rules_bid//build:docker_run"),
+            default = Label("@rules_bid//build:docker_run"),
             executable = True,
             cfg = "host",
         ),


### PR DESCRIPTION
Migrates the repository to use `rules_bid` version 2.2.2 instead of the old `bazel_rules_bid` module name.

Commits:
- chore: migrate to rules_bid 2.2.2

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt:
for each repository so identified, check it out locally and migrate it from bazel_rules_bid to rules_bid version 2.2.2. rules_bid should only be used

for each, send PR that does this