### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,13 +3,13 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_python", version = "1.6.3")
-bazel_dep(name = "rules_shell", version = "0.6.1")
-bazel_dep(name = "rules_shar", version = "0.5.0")
+bazel_dep(name = "rules_python", version = "2.0.2")
+bazel_dep(name = "rules_shell", version = "0.8.0")
+bazel_dep(name = "rules_shar", version = "1.0.7")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_bid", version = "2.2.2")
-bazel_dep(name = "gazelle", version = "0.47.0")
-bazel_dep(name = "rules_go", version = "0.59.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "rules_go", version = "0.61.1")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.from_file(go_mod = "//:go.mod")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_python: 1.6.3 -> 2.0.2
* rules_shell: 0.6.1 -> 0.8.0
* rules_shar: 0.5.0 -> 1.0.7
* gazelle: 0.47.0 -> 0.51.3
* rules_go: 0.59.0 -> 0.61.1